### PR TITLE
Add StaticBody2D node to Enemy scene

### DIFF
--- a/Enemy/Enemy.tscn
+++ b/Enemy/Enemy.tscn
@@ -1,3 +1,5 @@
 [gd_scene format=3 uid="uid://blasg4ic50mbl"]
 
 [node name="Enemy" type="CharacterBody2D"]
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]


### PR DESCRIPTION
Introduces a StaticBody2D node as a child of the Enemy node in Enemy.tscn. This may be for collision or environmental interaction purposes.