### PR TITLE
Adjust UI layering and collision settings

### DIFF
--- a/Floor Generator/Map.tscn
+++ b/Floor Generator/Map.tscn
@@ -8,9 +8,10 @@
 z_index = -5
 script = ExtResource("1_gfjgm")
 
-[node name="BattleUi" parent="." instance=ExtResource("2_sfgjq")]
-
 [node name="Player" parent="." instance=ExtResource("3_hry6r")]
 z_index = 5
 position = Vector2(1049, 438)
 scale = Vector2(0.2, 0.2)
+
+[node name="BattleUi" parent="." instance=ExtResource("2_sfgjq")]
+z_index = 20

--- a/Floor Generator/Rooms/Room_Default.tscn
+++ b/Floor Generator/Rooms/Room_Default.tscn
@@ -33,6 +33,8 @@ color = Color(0.80049086, 0.80049074, 0.80049074, 1)
 polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
 
 [node name="Colliders" type="StaticBody2D" parent="Wall_Container"]
+collision_layer = 4
+collision_mask = 35
 
 [node name="Collision_Left" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
 polygon = PackedVector2Array(0, 1106, 0, 0, 24, 0, 24, 1106)

--- a/UI/Battle UI.tscn
+++ b/UI/Battle UI.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://s8jg07gnon5g"]
 
-[ext_resource type="Script" uid="uid://yaocpo1x1yp5" path="res://UI/battle_ui.gd" id="1_63iuo"]
+[ext_resource type="Script" path="res://UI/battle_ui.gd" id="1_63iuo"]
 [ext_resource type="Script" uid="uid://bn8pkvjy0qrvu" path="res://UI/progress_bar.gd" id="1_qe2yl"]
 [ext_resource type="PackedScene" uid="uid://bg7nvpx2k4076" path="res://UI/pausebutton.tscn" id="2_q858a"]
 
@@ -68,6 +68,7 @@ text = "Floor 1"
 label_settings = SubResource("LabelSettings_63iuo")
 
 [node name="HBoxContainer" type="HBoxContainer" parent="HBoxContainer/VBoxContainer"]
+z_index = 10
 custom_minimum_size = Vector2(320, 100)
 layout_mode = 2
 size_flags_vertical = 10


### PR DESCRIPTION
Moved BattleUi node after Player and set its z_index to 20 in Map.tscn for proper layering. Added collision_layer and collision_mask to Colliders in Room_Default.tscn. Set z_index for HBoxContainer in Battle UI.tscn to ensure correct UI stacking.



- Wall layer set to 3
- mask layer 1 2 6
- UI zindex 10
- UI hboxcontainer (inventory) zindex 10