### PR TITLE
Call pickup_golf_ball on player hit

### DIFF
--- a/Scenes/ball_physics_playground/ball_physics_v2/Base_ball2.gd
+++ b/Scenes/ball_physics_playground/ball_physics_v2/Base_ball2.gd
@@ -44,7 +44,10 @@ var last_enemy_hit_time: float = 0.0
 func on_hit(target):
 	if target.is_in_group("Player") and is_real:
 		GameController.has_ball = true
-		is_real = false
+		if target.has_method("pickup_golf_ball"):
+			print("YOU GOT ME")
+			target.pickup_golf_ball()
+			is_real = false
 		#call_deferred("queue_free")
 		vanish_now()
 		return


### PR DESCRIPTION
When the ball hits a player, it now checks for and calls the player's pickup_golf_ball method before setting is_real to false. This enables custom pickup logic for the player.