### PR TITLE
Add floating damage number system

### DIFF
--- a/Game/Damage_number.gd
+++ b/Game/Damage_number.gd
@@ -1,0 +1,38 @@
+extends Node2D
+
+@export var float_distance := 5.0
+@export var duration := 10
+
+@onready var label: Label = $Label
+
+func setup(amount: int, damage_type: String) -> void:
+	label.text = str(amount)
+
+	match damage_type:
+		"crit":
+			label.modulate = Color.RED
+		"heal":
+			label.modulate = Color.GREEN
+		_:
+			label.modulate = Color.WHITE
+
+func _ready() -> void:
+	animate()
+
+func animate() -> void:
+	var tween := create_tween()
+	tween.tween_property(
+		self,
+		"position:y",
+		position.y - float_distance,
+		duration
+	).set_trans(Tween.TRANS_SINE).set_ease(Tween.EASE_OUT)
+
+	tween.parallel().tween_property(
+		self,
+		"modulate:a",
+		0.0,
+		duration
+	)
+
+	tween.finished.connect(queue_free)

--- a/Game/Damage_number.gd
+++ b/Game/Damage_number.gd
@@ -16,7 +16,6 @@ func setup(amount: int, damage_type: String) -> void:
 		_:
 			label.modulate = Color.WHITE
 
-func _ready() -> void:
 	animate()
 
 func animate() -> void:

--- a/Game/Damage_number.gd
+++ b/Game/Damage_number.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 @export var float_distance := 5.0
-@export var duration := 10
+@export var duration: float = 1.0
 
 @onready var label: Label = $Label
 

--- a/Game/Damage_number.gd.uid
+++ b/Game/Damage_number.gd.uid
@@ -1,0 +1,1 @@
+uid://72ysx3pdhkgm

--- a/Game/global_damage_number_manager.gd
+++ b/Game/global_damage_number_manager.gd
@@ -9,6 +9,9 @@ func show_damage(
 	damage_type: String = "normal"
 ) -> void:
 	var dmg = DAMAGE_NUMBER_SCENE.instantiate()
-	get_tree().current_scene.add_child(dmg)
+	var current_scene := get_tree().current_scene
+	if current_scene == null:
+		return
+	current_scene.add_child(dmg)
 	dmg.global_position = world_position
 	dmg.setup(amount, damage_type)

--- a/Game/global_damage_number_manager.gd
+++ b/Game/global_damage_number_manager.gd
@@ -1,0 +1,14 @@
+extends Node
+
+
+const DAMAGE_NUMBER_SCENE := preload("res://Scenes/Damage_number_label.tscn")
+
+func show_damage(
+	amount: int,
+	world_position: Vector2,
+	damage_type: String = "normal"
+) -> void:
+	var dmg = DAMAGE_NUMBER_SCENE.instantiate()
+	get_tree().current_scene.add_child(dmg)
+	dmg.global_position = world_position
+	dmg.setup(amount, damage_type)

--- a/Game/global_damage_number_manager.gd.uid
+++ b/Game/global_damage_number_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bppxp0u31clm8

--- a/Looting/Ball loot/Basic Ball.tscn
+++ b/Looting/Ball loot/Basic Ball.tscn
@@ -12,7 +12,7 @@
 script = ExtResource("3_gqhsa")
 metadata/_custom_type_script = "uid://d33cw4ow4a6pr"
 
-[sub_resource type="Resource" id="Resource_vfgpk"]
+[sub_resource type="Resource" id="Resource_efyh2"]
 script = ExtResource("5_efyh2")
 metadata/_custom_type_script = "uid://bsimgfnyiq71n"
 
@@ -20,7 +20,7 @@ metadata/_custom_type_script = "uid://bsimgfnyiq71n"
 script = ExtResource("2_gqhsa")
 ball_stats = ExtResource("3_pdn3r")
 physics_mode = SubResource("Resource_mr13q")
-split_mode = SubResource("Resource_vfgpk")
+split_mode = SubResource("Resource_efyh2")
 special_modes = Array[ExtResource("5_fmkav")]([])
 total_push_power = 2500.0
 is_real = true

--- a/Scenes/Damage_number_label.tscn
+++ b/Scenes/Damage_number_label.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=2 format=3 uid="uid://bw5jb6ym1lyiu"]
+
+[ext_resource type="Script" uid="uid://72ysx3pdhkgm" path="res://Game/Damage_number.gd" id="1_nelfo"]
+
+[node name="Node2D" type="Node2D"]
+script = ExtResource("1_nelfo")
+
+[node name="Label" type="Label" parent="."]
+offset_right = 365.2174
+offset_bottom = 210.0

--- a/Scenes/Damage_number_label.tscn
+++ b/Scenes/Damage_number_label.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://72ysx3pdhkgm" path="res://Game/Damage_number.gd" id="1_nelfo"]
 
-[node name="Node2D" type="Node2D"]
+[node name="DamageNumberLabel" type="Node2D"]
 script = ExtResource("1_nelfo")
 
 [node name="Label" type="Label" parent="."]

--- a/Scenes/Damage_number_label.tscn
+++ b/Scenes/Damage_number_label.tscn
@@ -6,5 +6,5 @@
 script = ExtResource("1_nelfo")
 
 [node name="Label" type="Label" parent="."]
-offset_right = 365.2174
-offset_bottom = 210.0
+offset_right = 64.0
+offset_bottom = 32.0

--- a/Scenes/ball_physics_playground/ball_physics_v2/Base_ball2.gd
+++ b/Scenes/ball_physics_playground/ball_physics_v2/Base_ball2.gd
@@ -80,6 +80,7 @@ func trigger_enemy_hit(target):
 	print("Hit accepted (0.1s passed)")
 	if target.has_method("take_damage"):
 			target.take_damage(ball_stats.damage)
+			Damage_number_manager.show_damage(ball_stats.damage, target.global_position)
 	if target.has_method("take_knockback"):
 			target.take_knockback(200.0, self.global_position, base_enemy.knockback_source.BALL)
 

--- a/Scenes/ball_physics_playground/golf_ball_playground.tscn
+++ b/Scenes/ball_physics_playground/golf_ball_playground.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=8 format=4 uid="uid://bdrfjnnkv44jw"]
 
 [ext_resource type="Script" uid="uid://cewcwq1jiw1wu" path="res://Scenes/ball_physics_playground/test_scene.gd" id="1_etr25"]
-[ext_resource type="PackedScene" uid="uid://c25x2820c8blr" path="res://Scenes/ball_physics_playground/ball_physics_v2/golf_ball_V2.tscn" id="2_55sa6"]
+[ext_resource type="PackedScene" uid="uid://c25x2820c8blr" path="res://Looting/Ball loot/Basic Ball.tscn" id="2_55sa6"]
 [ext_resource type="Texture2D" uid="uid://cptdc834m7360" path="res://Scenes/ball_physics_playground/test_assets/S1P5_game_Tilemap1_dungeon.png" id="3_gvtri"]
 [ext_resource type="PackedScene" uid="uid://bnnwxs6yonby6" path="res://Scenes/ball_physics_playground/Test Traps/TestAreas/TestSand/Sand Area.tscn" id="4_55sa6"]
 

--- a/project.godot
+++ b/project.godot
@@ -22,7 +22,7 @@ GameController="*res://Game/GameController.gd"
 Stats="*res://Game/Stats.gd"
 BallGacha="*res://Looting/scripts/Ball gacha.gd"
 StickGacha="*res://Looting/scripts/Stick gacha.gd"
-Damage_number_manager="*res://Game/global_damage_number_manager.gd"
+DamageNumberManager="*res://Game/global_damage_number_manager.gd"
 
 [display]
 

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,7 @@ GameController="*res://Game/GameController.gd"
 Stats="*res://Game/Stats.gd"
 BallGacha="*res://Looting/scripts/Ball gacha.gd"
 StickGacha="*res://Looting/scripts/Stick gacha.gd"
+Damage_number_manager="*res://Game/global_damage_number_manager.gd"
 
 [display]
 
@@ -76,13 +77,13 @@ interact={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"location":0,"echo":false,"script":null)
 ]
 }
-Inventory={
-"deadzone": 0.2,
-"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
-]
-}
 shove={
 "deadzone": 0.2,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+Inventory={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":69,"key_label":0,"unicode":101,"location":0,"echo":false,"script":null)
 ]
 }


### PR DESCRIPTION
Introduced a new system to display floating damage numbers when enemies are hit. Added Damage_number.gd and global_damage_number_manager.gd scripts, a Damage_number_label scene, and integrated the manager into Base_ball2.gd. Updated project settings and scene references to support the new feature.