### PR TITLE
Add boss, combat, and loot rooms to floor generator

### DIFF
--- a/Characters/Player/resource/Playerstats.tres
+++ b/Characters/Player/resource/Playerstats.tres
@@ -4,5 +4,6 @@
 
 [resource]
 script = ExtResource("1_67fyh")
-move_speed = 250.0
+start_health = 99999.0
+move_speed = 450.0
 metadata/_custom_type_script = "uid://bpdb85wqti2b3"

--- a/Floor Generator/Map_Generator/Map_Generator.gd
+++ b/Floor Generator/Map_Generator/Map_Generator.gd
@@ -23,7 +23,14 @@ func generate_floor() -> void:
 	
 	var new_rooms: Dictionary[Vector2, Room_Data] = generate_rooms(generate_walker_map())
 	
+	var room_counts: Dictionary[String, int] = {}
+	
 	for room in new_rooms:
 		var room_data: Room_Data = new_rooms[room]
-		var room_location_string: String = room_pool_manager.generate_room_from_data(room_data)
+		var room_instance_data: Array[String] = room_pool_manager.generate_room_from_data(room_data, room_counts)
+		var room_location_string: String = room_instance_data[0]
+		room_counts.get_or_add(room_instance_data[1], 0)
+		room_counts[room_instance_data[1]] += 1
 		RoomObject.new(room_data, room_location_string, get_viewport_rect().size)
+
+	print(room_counts)

--- a/Floor Generator/Map_Generator/Map_Generator.gd
+++ b/Floor Generator/Map_Generator/Map_Generator.gd
@@ -27,7 +27,7 @@ func generate_floor() -> void:
 	
 	for room in new_rooms:
 		var room_data: Room_Data = new_rooms[room]
-		var room_instance_data: Array[String] = room_pool_manager.generate_room_from_data(room_data, room_counts)
+		var room_instance_data: Array[String] = room_pool_manager.generate_room_from_data(room_data, room_counts, new_rooms.size())
 		var room_location_string: String = room_instance_data[0]
 		room_counts.get_or_add(room_instance_data[1], 0)
 		room_counts[room_instance_data[1]] += 1

--- a/Floor Generator/Rooms/Data/Room_Distribution.json
+++ b/Floor Generator/Rooms/Data/Room_Distribution.json
@@ -1,0 +1,5 @@
+{
+	"combat": 25,
+	"loot": 5,
+	"default": 70
+}

--- a/Floor Generator/Rooms/Data/Room_Pools_Data.json
+++ b/Floor Generator/Rooms/Data/Room_Pools_Data.json
@@ -19,10 +19,10 @@
 	  "conditions": {
 		"min_instances": 1,
 		"max_instances": 1,
-		"guaranteed_roll_chance": 1
+		"guaranteed_roll_chance": true
 	  },
 	  "rooms": [
-        "res://Floor Generator/Rooms/Presets/Room_Loot.tscn"
+        "res://Floor Generator/Rooms/Presets/Room_Exit.tscn"
 	  ]	
 	},
 	{
@@ -31,10 +31,10 @@
 	  "conditions": {
 		"min_instances": 1,
 		"max_instances": 1,
-		"guaranteed_roll_chance": 1
+		"guaranteed_roll_chance": true
 	  },
 	  "rooms": [
-        "res://Floor Generator/Rooms/Presets/Room_Loot.tscn"
+        "res://Floor Generator/Rooms/Presets/Room_Boss.tscn"
 	  ]	
 	},
 	{
@@ -42,7 +42,7 @@
 	  "priority": 100,
 	  "conditions": {
 		"door_count_gte": 2,
-		"roll_chance": 25
+		"roll_chance": 50
 	  },
 	  "rooms": [
         "res://Floor Generator/Rooms/Presets/Room_Combat.tscn"

--- a/Floor Generator/Rooms/Data/Room_Pools_Data.json
+++ b/Floor Generator/Rooms/Data/Room_Pools_Data.json
@@ -2,7 +2,7 @@
   "room_pools": [
 	{
 	  "id": "spawn",
-	  "priority": 999,
+	  "priority": 9999,
 	  "conditions": {
 		"position_equals": [
 		  0,
@@ -12,6 +12,52 @@
 	  "rooms": [
         "res://Floor Generator/Rooms/Presets/Room_Spawn.tscn"
 	  ]
+	},
+	{
+	  "id": "exit",
+	  "priority": 600,
+	  "conditions": {
+		"min_instances": 1,
+		"max_instances": 1,
+		"guaranteed_roll_chance": 1
+	  },
+	  "rooms": [
+        "res://Floor Generator/Rooms/Presets/Room_Loot.tscn"
+	  ]	
+	},
+	{
+	  "id": "boss",
+	  "priority": 500,
+	  "conditions": {
+		"min_instances": 1,
+		"max_instances": 1,
+		"guaranteed_roll_chance": 1
+	  },
+	  "rooms": [
+        "res://Floor Generator/Rooms/Presets/Room_Loot.tscn"
+	  ]	
+	},
+	{
+	  "id": "combat",
+	  "priority": 100,
+	  "conditions": {
+		"door_count_gte": 2,
+		"roll_chance": 25
+	  },
+	  "rooms": [
+        "res://Floor Generator/Rooms/Presets/Room_Combat.tscn"
+	  ]	
+	},
+	{
+	  "id": "loot",
+	  "priority": 95,
+	  "conditions": {
+		"door_count_lte": 1,
+		"roll_chance": 50
+	  },
+	  "rooms": [
+        "res://Floor Generator/Rooms/Presets/Room_Loot.tscn"
+	  ]	
 	},
 	{
 	  "id": "default",

--- a/Floor Generator/Rooms/Presets/Room_Boss.tscn
+++ b/Floor Generator/Rooms/Presets/Room_Boss.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=2 format=3 uid="uid://bte0i20clrjw5"]
+
+[sub_resource type="NavigationPolygon" id="NavigationPolygon_g6fcb"]
+vertices = PackedVector2Array(1886, 1070, 34, 1070, 34, 36, 1886, 36)
+polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
+outlines = Array[PackedVector2Array]([PackedVector2Array(24, 26, 1896, 26, 1896, 1080, 24, 1080)])
+
+[node name="DefaultRoom" type="Node2D"]
+metadata/DoorPositions = {
+Vector2i(-1, 0): Vector2i(0, 540),
+Vector2i(0, -1): Vector2i(960, 0),
+Vector2i(0, 1): Vector2i(960, 1080),
+Vector2i(1, 0): Vector2i(1920, 540)
+}
+
+[node name="Floor" type="Polygon2D" parent="."]
+color = Color(0.40069768, 0.4006978, 0.40069735, 1)
+polygon = PackedVector2Array(1920, 0, 1920, 1080, 0, 1080, 0, 0)
+
+[node name="Wall_Container" type="Node2D" parent="."]
+
+[node name="Wall_Top" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Wall_Bottom" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0016174316, 1080.0367, 1919.9999, 1080, 1919.9999, 1106, -0.00011444092, 1106)
+
+[node name="Wall_Left" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Wall_Right" type="Polygon2D" parent="Wall_Container"]
+position = Vector2(1896, 0)
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Colliders" type="StaticBody2D" parent="Wall_Container"]
+collision_layer = 4
+collision_mask = 35
+
+[node name="Collision_Left" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1106, 0, 0, 24, 0, 24, 1106)
+
+[node name="Collision_Right" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(1920, 0, 1896, 0, 1896, 1106, 1920, 1106)
+
+[node name="Collision_Top" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 0, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Collision_Bottom" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1080, 1920, 1080, 1920, 1106, 0, 1106)
+
+[node name="NavMesh2D" type="NavigationRegion2D" parent="."]
+navigation_polygon = SubResource("NavigationPolygon_g6fcb")

--- a/Floor Generator/Rooms/Presets/Room_Boss.tscn
+++ b/Floor Generator/Rooms/Presets/Room_Boss.tscn
@@ -1,4 +1,6 @@
-[gd_scene load_steps=2 format=3 uid="uid://bte0i20clrjw5"]
+[gd_scene load_steps=3 format=3 uid="uid://bte0i20clrjw5"]
+
+[ext_resource type="Texture2D" uid="uid://bdrrno1kjtgny" path="res://Characters/Enemy/slime.png" id="1_3vvy7"]
 
 [sub_resource type="NavigationPolygon" id="NavigationPolygon_g6fcb"]
 vertices = PackedVector2Array(1886, 1070, 34, 1070, 34, 36, 1886, 36)
@@ -54,3 +56,7 @@ polygon = PackedVector2Array(0, 1080, 1920, 1080, 1920, 1106, 0, 1106)
 
 [node name="NavMesh2D" type="NavigationRegion2D" parent="."]
 navigation_polygon = SubResource("NavigationPolygon_g6fcb")
+
+[node name="Slime" type="Sprite2D" parent="."]
+position = Vector2(982, 614)
+texture = ExtResource("1_3vvy7")

--- a/Floor Generator/Rooms/Presets/Room_Combat.tscn
+++ b/Floor Generator/Rooms/Presets/Room_Combat.tscn
@@ -1,0 +1,78 @@
+[gd_scene load_steps=3 format=3 uid="uid://d1wxeckua643m"]
+
+[ext_resource type="PackedScene" uid="uid://c2oixgv23yhvi" path="res://Characters/Enemy/Enemy.tscn" id="1_52snu"]
+
+[sub_resource type="NavigationPolygon" id="NavigationPolygon_g6fcb"]
+vertices = PackedVector2Array(1886, 1070, 34, 1070, 34, 36, 1886, 36)
+polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
+outlines = Array[PackedVector2Array]([PackedVector2Array(24, 26, 1896, 26, 1896, 1080, 24, 1080)])
+
+[node name="DefaultRoom" type="Node2D"]
+metadata/DoorPositions = {
+Vector2i(-1, 0): Vector2i(0, 540),
+Vector2i(0, -1): Vector2i(960, 0),
+Vector2i(0, 1): Vector2i(960, 1080),
+Vector2i(1, 0): Vector2i(1920, 540)
+}
+
+[node name="Floor" type="Polygon2D" parent="."]
+color = Color(0.40069768, 0.4006978, 0.40069735, 1)
+polygon = PackedVector2Array(1920, 0, 1920, 1080, 0, 1080, 0, 0)
+
+[node name="Wall_Container" type="Node2D" parent="."]
+
+[node name="Wall_Top" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Wall_Bottom" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0016174316, 1080.0367, 1919.9999, 1080, 1919.9999, 1106, -0.00011444092, 1106)
+
+[node name="Wall_Left" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Wall_Right" type="Polygon2D" parent="Wall_Container"]
+position = Vector2(1896, 0)
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Colliders" type="StaticBody2D" parent="Wall_Container"]
+collision_layer = 4
+collision_mask = 35
+
+[node name="Collision_Left" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1106, 0, 0, 24, 0, 24, 1106)
+
+[node name="Collision_Right" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(1920, 0, 1896, 0, 1896, 1106, 1920, 1106)
+
+[node name="Collision_Top" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 0, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Collision_Bottom" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1080, 1920, 1080, 1920, 1106, 0, 1106)
+
+[node name="NavMesh2D" type="NavigationRegion2D" parent="."]
+navigation_polygon = SubResource("NavigationPolygon_g6fcb")
+
+[node name="MeleeEnemy" parent="." instance=ExtResource("1_52snu")]
+position = Vector2(307, 537)
+scale = Vector2(0.2, 0.2)
+
+[node name="MeleeEnemy2" parent="." instance=ExtResource("1_52snu")]
+position = Vector2(748, 627)
+scale = Vector2(0.2, 0.2)
+
+[node name="MeleeEnemy3" parent="." instance=ExtResource("1_52snu")]
+position = Vector2(1186, 603)
+scale = Vector2(0.2, 0.2)
+
+[node name="MeleeEnemy4" parent="." instance=ExtResource("1_52snu")]
+position = Vector2(689, 268.00003)
+scale = Vector2(0.2, 0.2)
+
+[node name="MeleeEnemy5" parent="." instance=ExtResource("1_52snu")]
+position = Vector2(1322, 447)
+scale = Vector2(0.2, 0.2)

--- a/Floor Generator/Rooms/Presets/Room_Loot.tscn
+++ b/Floor Generator/Rooms/Presets/Room_Loot.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=3 format=3 uid="uid://4u8itrg8vpdy"]
+
+[ext_resource type="Texture2D" uid="uid://bnraft7toiyow" path="res://icon.svg" id="1_kdvc1"]
+
+[sub_resource type="NavigationPolygon" id="NavigationPolygon_g6fcb"]
+vertices = PackedVector2Array(1886, 1070, 34, 1070, 34, 36, 1886, 36)
+polygons = Array[PackedInt32Array]([PackedInt32Array(0, 1, 2, 3)])
+outlines = Array[PackedVector2Array]([PackedVector2Array(24, 26, 1896, 26, 1896, 1080, 24, 1080)])
+
+[node name="DefaultRoom" type="Node2D"]
+metadata/DoorPositions = {
+Vector2i(-1, 0): Vector2i(0, 540),
+Vector2i(0, -1): Vector2i(960, 0),
+Vector2i(0, 1): Vector2i(960, 1080),
+Vector2i(1, 0): Vector2i(1920, 540)
+}
+
+[node name="Floor" type="Polygon2D" parent="."]
+color = Color(0.40069768, 0.4006978, 0.40069735, 1)
+polygon = PackedVector2Array(1920, 0, 1920, 1080, 0, 1080, 0, 0)
+
+[node name="Wall_Container" type="Node2D" parent="."]
+
+[node name="Wall_Top" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Wall_Bottom" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0016174316, 1080.0367, 1919.9999, 1080, 1919.9999, 1106, -0.00011444092, 1106)
+
+[node name="Wall_Left" type="Polygon2D" parent="Wall_Container"]
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Wall_Right" type="Polygon2D" parent="Wall_Container"]
+position = Vector2(1896, 0)
+color = Color(0.80049086, 0.80049074, 0.80049074, 1)
+polygon = PackedVector2Array(-0.0015044947, 0.03675685, 24.021412, 0.024762243, 24, 1106, 0, 1106)
+
+[node name="Colliders" type="StaticBody2D" parent="Wall_Container"]
+collision_layer = 4
+collision_mask = 35
+
+[node name="Collision_Left" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1106, 0, 0, 24, 0, 24, 1106)
+
+[node name="Collision_Right" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(1920, 0, 1896, 0, 1896, 1106, 1920, 1106)
+
+[node name="Collision_Top" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 0, 1920, 0, 1920, 26, 0, 26)
+
+[node name="Collision_Bottom" type="CollisionPolygon2D" parent="Wall_Container/Colliders"]
+polygon = PackedVector2Array(0, 1080, 1920, 1080, 1920, 1106, 0, 1106)
+
+[node name="NavMesh2D" type="NavigationRegion2D" parent="."]
+navigation_polygon = SubResource("NavigationPolygon_g6fcb")
+
+[node name="Icon" type="Sprite2D" parent="."]
+position = Vector2(973, 563.00006)
+scale = Vector2(1.9765625, 1.9765625)
+texture = ExtResource("1_kdvc1")

--- a/Floor Generator/Rooms/Scripts/Room_Pool_Manager.gd
+++ b/Floor Generator/Rooms/Scripts/Room_Pool_Manager.gd
@@ -18,41 +18,63 @@ func _init(pools_json_location: String) -> void:
 		func(a: RoomPool, b: RoomPool) -> bool:
 			return a.priority > b.priority)
 
-func build_context(data: Room_Data) -> Dictionary:
+func build_context(data: Room_Data, room_counts: Dictionary[String, int], total_rooms: int) -> Dictionary:
 	return {
 		"grid_position": data.grid_position,
 		"doors": data.doors,
 		"door_count": data.doors.size(),
-		"random_roll": RandomNumberGenerator.new().randi_range(0, 100)
+		"random_roll": RandomNumberGenerator.new().randi_range(1, 100),
+		"room_counts": room_counts,
+		"total_rooms": total_rooms
 	}
 
-func check_condition(key: String, value, ctx: Dictionary) -> bool:
-	# Missing some keys, will give warnings
+
+func check_condition(key: String, value, ctx: Dictionary, pool_id: String) -> bool:
+	var count: int = ctx.room_counts.get(pool_id, 0)
+	var current_rooms: int = 0
+	for room in ctx.room_counts:
+		current_rooms += ctx.room_counts[room]
+
 	match key:
 		"position_equals":
 			return ctx.grid_position == Vector2(value[0], value[1])
 
 		"door_count_gte":
 			return ctx.door_count >= int(value)
-			
+
 		"door_count_lte":
 			return ctx.door_count <= int(value)
-			
+
+		"guaranteed_roll_chance":
+			var exp: float = 5.0 # How far back do we push the special rooms
+			var special_rooms: int = 2
+			var treshold: float = pow((float(current_rooms) + special_rooms)/ctx.total_rooms, exp) * 100
+			print(pool_id + " chance: " + str(treshold))
+			return ctx.random_roll <= treshold
+
 		"roll_chance":
 			return ctx.random_roll <= int(value)
+
+		"min_instances":
+			return count < int(value)
+
+		"max_instances":
+			return count < int(value)
 
 		_:
 			push_warning("Unknown condition: %s" % key)
 			return false
 
+
 func pool_matches(pool: RoomPool, ctx: Dictionary) -> bool:
 	for key in pool.conditions.keys():
-		if not check_condition(key, pool.conditions[key], ctx):
+		if not check_condition(key, pool.conditions[key], ctx, pool.id):
 			return false
 	return true
+
 	
-func generate_room_from_data(room_data: Room_Data, room_counts: Dictionary[String, int]) -> Array[String]:
-	var ctx := build_context(room_data)
+func generate_room_from_data(room_data: Room_Data, room_counts: Dictionary[String, int], total_rooms: int) -> Array[String]:
+	var ctx := build_context(room_data, room_counts, total_rooms)
 
 	for pool in ordered_pools:
 		if pool_matches(pool, ctx):

--- a/Floor Generator/Rooms/Scripts/Room_Pool_Manager.gd
+++ b/Floor Generator/Rooms/Scripts/Room_Pool_Manager.gd
@@ -22,16 +22,24 @@ func build_context(data: Room_Data) -> Dictionary:
 	return {
 		"grid_position": data.grid_position,
 		"doors": data.doors,
-		"door_count": data.doors.size()
+		"door_count": data.doors.size(),
+		"random_roll": RandomNumberGenerator.new().randi_range(0, 100)
 	}
 
 func check_condition(key: String, value, ctx: Dictionary) -> bool:
+	# Missing some keys, will give warnings
 	match key:
 		"position_equals":
 			return ctx.grid_position == Vector2(value[0], value[1])
 
 		"door_count_gte":
 			return ctx.door_count >= int(value)
+			
+		"door_count_lte":
+			return ctx.door_count <= int(value)
+			
+		"roll_chance":
+			return ctx.random_roll <= int(value)
 
 		_:
 			push_warning("Unknown condition: %s" % key)
@@ -43,12 +51,12 @@ func pool_matches(pool: RoomPool, ctx: Dictionary) -> bool:
 			return false
 	return true
 	
-func generate_room_from_data(room_data: Room_Data) -> String:
+func generate_room_from_data(room_data: Room_Data, room_counts: Dictionary[String, int]) -> Array[String]:
 	var ctx := build_context(room_data)
 
 	for pool in ordered_pools:
 		if pool_matches(pool, ctx):
-			return pool.get_random_room()
+			return [pool.get_random_room(), pool.id]
 
 	push_error("No valid room pool found")
-	return ""
+	return [""]


### PR DESCRIPTION
Introduced new room presets for boss, combat, and loot rooms, and updated room pool data to include these types with appropriate conditions and priorities. Enhanced the map generator and room pool manager scripts to support room type distribution and instance counting. Also adjusted player starting stats for testing.