### PR TITLE
Add cutscene phase and update intro cutscene flow

### DIFF
--- a/Game/GameController.gd
+++ b/Game/GameController.gd
@@ -9,11 +9,12 @@ enum GamePhase {
 	TRAVEL,
 	COMBAT,
 	TREASURE,
-	DEATH
+	DEATH,
+	CUTSCENE
 }
 var Main_scene: String = "res://Scenes/Main menu.tscn"
-var Death_scene: String = ""
-var Dungeon_scene: String = "res://Movies/intro_cutscene.tscn"
+var Dungeon_scene: String = "res://Floor Generator/Map.tscn"
+var Intro_scene: String = "res://Movies/intro_cutscene.tscn"
 var current_phase: GamePhase = GamePhase.MAIN
 
 #inventory
@@ -53,6 +54,11 @@ func set_phase(new_phase: GamePhase):
 			set_game_speed(1)
 			clear_run_data()
 			get_tree().change_scene_to_file(Dungeon_scene)
+			get_tree().paused = false
+		GamePhase.CUTSCENE:
+			set_game_speed(1)
+			clear_run_data()
+			get_tree().change_scene_to_file(Intro_scene)
 			get_tree().paused = false
 		GamePhase.LOAD_GAME:
 			set_game_speed(1)

--- a/Movies/intro_cutscene.gd
+++ b/Movies/intro_cutscene.gd
@@ -5,7 +5,6 @@ extends Node2D
 @export var dungeonFloor: Node2D
 @export var tilemapLayer: TileMapLayer
 @export var playerModel: Node2D
-@export var spawnRoom: PackedScene
 @export var skipButton: Button
 
 var skipped := false
@@ -14,7 +13,6 @@ var skipped := false
 func _ready() -> void:
 	assert(animationPlayer)
 	assert(tilemapLayer)
-	assert(spawnRoom)
 
 	# Initial state
 	dungeonFloor.visible = false
@@ -66,4 +64,4 @@ func _finish_intro() -> void:
 	tilemapLayer.visible = false
 
 	# Transition
-	get_tree().change_scene_to_packed(spawnRoom)
+	GameController.set_phase(GameController.GamePhase.NEW_GAME)

--- a/Movies/intro_cutscene.tscn
+++ b/Movies/intro_cutscene.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=23 format=4 uid="uid://baja54ggpyi0i"]
+[gd_scene load_steps=22 format=4 uid="uid://baja54ggpyi0i"]
 
 [ext_resource type="Texture2D" uid="uid://drlfg8tda7xe" path="res://Assets/Cutscene intro/Spotlight.png" id="1_0gpnn"]
 [ext_resource type="Script" uid="uid://dm4mlny11m3dr" path="res://Movies/intro_cutscene.gd" id="1_1gu3r"]
-[ext_resource type="PackedScene" uid="uid://b34r35nai5s4p" path="res://Floor Generator/Map.tscn" id="2_1gu3r"]
 [ext_resource type="PackedScene" uid="uid://cp7t6of0cxh0s" path="res://Movies/ball_cutscene.tscn" id="3_t53if"]
 [ext_resource type="Texture2D" uid="uid://ckr63a7a85ob4" path="res://Assets/kenney_sokoban-pack/PNG/Default size/Ground/ground_06.png" id="4_q2omu"]
 [ext_resource type="Texture2D" uid="uid://cgyre2dsa6gud" path="res://Assets/kenney_sokoban-pack/Tilesheet/sokoban_tilesheet.png" id="5_4gknm"]
@@ -1448,7 +1447,6 @@ animationPlayer = NodePath("AnimationPlayer")
 dungeonFloor = NodePath("DungeonFloor")
 tilemapLayer = NodePath("DungeonFloor/TileMapLayer")
 playerModel = NodePath("PlayerModel")
-spawnRoom = ExtResource("2_1gu3r")
 skipButton = NodePath("CanvasLayer/SkipButton")
 
 [node name="SpotlightLayer" type="CanvasLayer" parent="."]
@@ -1629,8 +1627,8 @@ rest = Transform2D(1, -0.00019209491, 0.00019209491, 1, -86, -37)
 
 [node name="RightHand" type="Bone2D" parent="PlayerModel/PivotPoint/Skeleton2D/Torso/RightArm"]
 position = Vector2(-18, 67)
-rotation = -0.285158
-scale = Vector2(0.99999994, 0.99999994)
+rotation = -0.28515798
+scale = Vector2(0.9999999, 0.9999999)
 rest = Transform2D(0.95961714, -0.28130904, 0.28130904, 0.95961714, -18, 67)
 
 [node name="LeftArm" type="Bone2D" parent="PlayerModel/PivotPoint/Skeleton2D/Torso"]

--- a/UI/main_menu.gd
+++ b/UI/main_menu.gd
@@ -17,7 +17,7 @@ func _on_quit_button_pressed() -> void:
 
 
 func _on_new_button_pressed() -> void:
-	GameController.set_phase(GameController.GamePhase.NEW_GAME)
+	GameController.set_phase(GameController.GamePhase.CUTSCENE)
 
 
 func _on_credits_button_pressed() -> void:


### PR DESCRIPTION
Introduced a CUTSCENE phase to GameController and refactored the intro cutscene logic to use this phase. The main menu now starts the cutscene instead of the game directly, and the cutscene transitions to the NEW_GAME phase upon completion. Removed unused spawnRoom references from the cutscene script and scene.