### PR TITLE
Fix enemy spawn parenting and update camera usage

### DIFF
--- a/Characters/Enemy/scripts/CombatManager.gd
+++ b/Characters/Enemy/scripts/CombatManager.gd
@@ -32,7 +32,7 @@ func _spawn_enemies(player : Node2D) -> void:
 		var pos : Vector2 = _get_valid_nav_position(nav_map.get_navigation_map(), player)
 		enemy.global_position = pos
 		
-		add_child(enemy)
+		get_parent().add_child(enemy)
 		enemies_alive += 1
 		enemy.connect("tree_exited", _on_enemy_removed)
 
@@ -51,7 +51,8 @@ func pick_weighted_enemy() -> PackedScene:
 
 func _get_valid_nav_position(nav_map : RID, player : Node2D) -> Vector2:
 	for i in range(20):
-		var candidate : Vector2 =  get_viewport_rect().size/2 + Vector2(
+		var camera : Camera2D = get_tree().get_root().get_node("Map/Slight_Zoom_Camera_Temp")
+		var candidate : Vector2 =  camera.get_screen_center_position() + Vector2(
 			randf_range(-200, 200),
 			randf_range(-200, 200)
 		)

--- a/Floor Generator/Map.tscn
+++ b/Floor Generator/Map.tscn
@@ -17,6 +17,6 @@ scale = Vector2(0.2, 0.2)
 top_level = true
 position = Vector2(960, 540)
 scale = Vector2(1.0999998, 1.0999998)
-zoom = Vector2(0.9, 0.9)
+zoom = Vector2(0.1, 0.1)
 
 [node name="BattleUi" parent="Slight_Zoom_Camera_Temp" instance=ExtResource("2_sfgjq")]

--- a/UI/main_menu.gd
+++ b/UI/main_menu.gd
@@ -9,7 +9,7 @@ func _ready() -> void:
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
 	if GameController.ball_slot1 != "res://Looting/Basic/Basic Ball.tscn" || GameController.ball_slot2 != "" || GameController.ball_slot3 != "" || GameController.stick_slot1 != "res://Looting/Basic/Basic Stick.tscn" || GameController.stick_slot2 != "" || GameController.stick_slot3 != "":
-		$MarginContainer/VBoxContainer/ContinueButton.disabled = false
+		$VBoxContainer/ContinueButton.disabled = false
 
 
 func _on_quit_button_pressed() -> void:


### PR DESCRIPTION
Enemies are now added to the parent's node instead of the CombatManager itself, ensuring correct scene hierarchy. The valid navigation position now uses the camera's screen center instead of the viewport center. Also, the camera zoom in Map.tscn is adjusted, and the Continue button path in main_menu.gd is fixed for proper enabling.